### PR TITLE
Add device naming template field

### DIFF
--- a/Deploy-Intune/Runbook Script/Deploy-Intune-Script.ps1
+++ b/Deploy-Intune/Runbook Script/Deploy-Intune-Script.ps1
@@ -139,6 +139,8 @@ param
     ,
     [string]$sendgridtoken #Sendgrid API token
     ,
+    [string]$devicename #Autopilot device name template
+    ,
     [object] $WebHookData #Webhook data for Azure Automation
 
     )
@@ -162,6 +164,7 @@ $emailsend = ((($bodyData.emailsend) | out-string).trim())
 $whitelabel = ((($bodyData.whitelabel) | out-string).trim())
 $fresh = ((($bodyData.fresh) | out-string).trim())
 $sendgridtoken = ((($bodyData.sendgridtoken) | out-string).trim())
+$devicename = ((($bodyData.devicename) | out-string).trim())
 
 $aadlogin = "yes"
 
@@ -7893,6 +7896,12 @@ $uri = "https://graph.microsoft.com/$graphApiVersion/$Resource"
     else {
         $profilename = "Autopilot Profile"
     }
+    if ($devicename) {
+        $deviceTemplate = $devicename
+    }
+    else {
+        $deviceTemplate = "%SERIAL%"
+    }
     $json = @"
     {
         "@odata.type": "#microsoft.graph.azureADWindowsAutopilotDeploymentProfile",
@@ -7900,7 +7909,7 @@ $uri = "https://graph.microsoft.com/$graphApiVersion/$Resource"
         "description": "OOBE Autopilot Profile",
         "language": "os-default",
         "extractHardwareHash": true,
-        "deviceNameTemplate": "%SERIAL%",
+        "deviceNameTemplate": "$deviceTemplate",
         "deviceType": "windowsPc",
         "enableWhiteGlove": true,
     	"outOfBoxExperienceSettings": {

--- a/Deploy-Intune/Webpage Content/index.php
+++ b/Deploy-Intune/Webpage Content/index.php
@@ -61,6 +61,7 @@ else {
   <li>The homepage field is a web URL (typically starting https://) which will be set as the default homepage in Microsoft Edge browser.</li>
   <li>Company Size has no impact on the deployment</li>
   <li>Entering a prefix will add it before all policies and Entra groups.  If left blank, it will default to "ID"</li>
+  <li>The Device Name Template controls how new Autopilot devices are named. Use values like <code>PC-%RAND:6%</code> or <code>DEVICE-%SERIAL%</code></li>
   <li>In the upload field, please add an image to be used as the desktop wallpaper/background on your Windows devices
     <br>
     This can be changed after deployment if required

--- a/Deploy-Intune/Webpage Content/process.php
+++ b/Deploy-Intune/Webpage Content/process.php
@@ -54,6 +54,7 @@ $prefix = $prefix . "-";
 if (empty($prefix)) {
     $prefix = "ID-";
 }
+$devicename = $_POST['devicename'];
 $noupload = "yes";
 if (isset($_POST['CAD'])) {
     $conditionals = "Yes";
@@ -132,6 +133,7 @@ $data = array(
     array("cad" => "$conditionals"),
     array("emailsend" => "$email"),
     array("whitelabel" => "$prefix"),
+    array("devicename" => "$devicename"),
     array("noupload" => "$noupload"),
     array("fresh" => "$fresh")
 );

--- a/Deploy-Intune/Webpage Content/setup-process.php
+++ b/Deploy-Intune/Webpage Content/setup-process.php
@@ -410,6 +410,19 @@ include "header.php";
               <tr>
                 <td>
                   <div class="input-container ic1">
+                    <input id="devicename" name="devicename" class="input" type="text" placeholder=" " />
+                    <div class="tooltip">
+                      <img src="tooltip.png" alt="Information" width="20" height="20">
+                      <span class="tooltiptext">Autopilot device name template (e.g. PC-%RAND:6%)</span>
+                    </div>
+                    <label for="devicename" class="placeholder">Device Name Template</label>
+                  </div>
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <div class="input-container ic1">
                     <label class="switch">
                       <input id="fresh" name="fresh" class="input" type="checkbox" placeholder=" " value="Yes" />
                       <span class="slider round"></span>


### PR DESCRIPTION
## Summary
- add `devicename` parameter to Deploy-Intune script
- support device name template in website form and processing
- document the new field on the landing page

## Testing
- `php -l "Deploy-Intune/Webpage Content/setup-process.php"` *(fails: command not found)*
- `pwsh -c 'Write-Host "PS"'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498a9e0fec8321bc8a35b9508d267c